### PR TITLE
Propogate uncompress error

### DIFF
--- a/lib/uncompress-stream.js
+++ b/lib/uncompress-stream.js
@@ -61,6 +61,9 @@ UncompressStream.prototype._parse = function (callback) {
   if (type === 'compressed') {
     // TODO: check that the checksum matches
     snappy.uncompress(data.slice(4), { asBuffer: this.asBuffer }, function (err, raw) {
+      if(err) {
+        return callback(err)
+      }
       self.push(raw)
       self._parse(callback)
     })


### PR DESCRIPTION
If a compressed chunk has an error when being uncompressed, we should propagate that error back to the user (current behaviour is the user simply gets no data since `raw` is undefined)